### PR TITLE
Fix DDA miniTDF reading, propagate error messages, clippy changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1019,7 +1019,7 @@ dependencies = [
 
 [[package]]
 name = "timsrust_pyo3"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "pyo3",
  "timsrust",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1003,9 +1003,9 @@ dependencies = [
 
 [[package]]
 name = "timsrust"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0791ad8b3836b6a582b1bfb563c04d0e09acdaf85e45c16d3158a0bcb164b6"
+checksum = "d35d63d446ce6278d71949dfdf2d618c5891cdb4de7c1306e9631997d7916779"
 dependencies = [
  "bytemuck",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = "0.19.0"
-timsrust = "0.2.2"
+timsrust = "0.2.3"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ I am happy to take requests and ideas.
 # Installation
 
 ```shell
-pip install git+https://github.com/jspaezp/timsrust_pyo3
+pip install timsrust_pyo3
 ```
 
 # Usage
@@ -18,7 +18,7 @@ pip install git+https://github.com/jspaezp/timsrust_pyo3
 >>> all_frames[0]
 PyFrame(index=1, rt=0.33491, frame_type=0, len(scan_offsets)=710, len(tof_indices)=242412, len(intensities)=242412)
 
->>> reader = timsrust_pyo3.TDFReader("some_file.d")
+>>> reader = timsrust_pyo3.TimsReader("some_file.d")
 >>> all_frames = reader.read_all_frames()
 >>> tfr.resolve_mzs(all_frames[0].tof_indices)
 [...] # list[float]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,36 +38,32 @@ impl TimsReader {
     #[new]
     fn new(path: String) -> PyResult<Self> {
         use pyo3::exceptions::PyIOError;
-        let reader = timsrust::FileReader::new(&path);
-        let reader = match reader {
+        let reader = match timsrust::FileReader::new(&path) {
             Ok(x) => x,
             Err(_) => return Err(PyIOError::new_err("Could not open file")),
         };
 
-        let fc = reader.get_frame_converter();
-        let fc = match fc {
+        let frame_converter = match reader.get_frame_converter() {
             Ok(x) => x,
-            Err(_) => return Err(PyIOError::new_err("Could not get frame converter")),
+            Err(e) => return Err(PyIOError::new_err(format!("Could not get frame converter: {e}"))),
         };
 
-        let sc = reader.get_scan_converter();
-        let sc = match sc {
+        let scan_converter = match reader.get_scan_converter() {
             Ok(x) => x,
-            Err(_) => return Err(PyIOError::new_err("Could not get scan converter")),
+            Err(e) => return Err(PyIOError::new_err(format!("Could not get scan converter: {e}"))),
         };
 
-        let tc = reader.get_tof_converter();
-        let tc = match tc {
+        let tof_converter = match reader.get_tof_converter() {
             Ok(x) => x,
-            Err(_) => return Err(PyIOError::new_err("Could not get tof converter")),
+            Err(e) => return Err(PyIOError::new_err(format!("Could not get tof converter: {e}"))),
         };
 
         Ok(TimsReader {
             reader,
             path,
-            frame_converter: fc,
-            scan_converter: sc,
-            tof_converter: tc,
+            frame_converter,
+            scan_converter,
+            tof_converter,
         })
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,10 +119,10 @@ impl TimsReader {
     }
 
     fn resolve_mzs(slf: &PyCell<Self>, tofs: Vec<u32>) -> PyResult<Vec<f64>> {
-        match &slf.borrow().reader.get_frame_converter() {
+        match &slf.borrow().reader.get_tof_converter() {
             Ok(c) => Ok(tofs.iter().map(|x| c.convert(*x)).collect()),
             Err(e) => Err(PyIOError::new_err(format!(
-                "Could not get frame converter: {e}"
+                "Could not get TOF converter: {e}"
             ))),
         }
     }
@@ -307,10 +307,7 @@ impl PyFrame {
 #[pyfunction]
 fn read_all_frames(path: String) -> PyResult<Vec<PyFrame>> {
     let reader = timsrust::FileReader::new(&path).unwrap();
-    let tims_reader = TimsReader {
-        reader,
-        path,
-    };
+    let tims_reader = TimsReader { reader, path };
     let out: Vec<PyFrame> = tims_reader.read_all_frames();
     Ok(out)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,15 @@
 use std::fmt::Display;
 
-use crate::timsrust::ConvertableIndex;
-use crate::timsrust::Frame;
-use crate::timsrust::FrameType;
-use crate::timsrust::Spectrum;
 use pyo3::prelude::*;
-use timsrust;
 use timsrust::AcquisitionType;
+use timsrust::ConvertableIndex;
+use timsrust::Frame;
+use timsrust::FrameType;
 use timsrust::QuadrupoleEvent;
+use timsrust::Spectrum;
 
 #[pyclass]
-struct TimsReader {
+pub struct TimsReader {
     #[pyo3(get)]
     pub path: String,
     pub reader: timsrust::FileReader,
@@ -20,17 +19,17 @@ struct TimsReader {
 }
 
 #[pyclass]
-struct Frame2RtConverter {
+pub struct Frame2RtConverter {
     pub converter: timsrust::Frame2RtConverter,
 }
 
 #[pyclass]
-struct Scan2ImConverter {
+pub struct Scan2ImConverter {
     pub converter: timsrust::Scan2ImConverter,
 }
 
 #[pyclass]
-struct Tof2MzConverter {
+pub struct Tof2MzConverter {
     pub converter: timsrust::Tof2MzConverter,
 }
 
@@ -64,8 +63,8 @@ impl TimsReader {
         };
 
         Ok(TimsReader {
-            reader: reader,
-            path: path,
+            reader,
+            path,
             frame_converter: fc,
             scan_converter: sc,
             tof_converter: tc,
@@ -98,7 +97,7 @@ impl TimsReader {
         self.reader
             .read_all_frames()
             .iter()
-            .map(|x| PyFrame::new(x))
+            .map(PyFrame::new)
             .collect()
     }
 
@@ -121,7 +120,7 @@ impl TimsReader {
         self.reader
             .read_all_ms1_frames()
             .iter()
-            .map(|x| PyFrame::new(x))
+            .map(PyFrame::new)
             .collect()
     }
 
@@ -133,7 +132,7 @@ impl TimsReader {
         self.reader
             .read_all_spectra()
             .iter()
-            .map(|x| PySpectrum::new(x))
+            .map(PySpectrum::new)
             .collect()
     }
 
@@ -245,7 +244,7 @@ impl PySpectrum {
             mz_values: scan.mz_values.to_owned(),
             intensities: scan.intensities.to_owned(),
             index: scan.index.to_owned(),
-            precursor: precursor,
+            precursor,
         }
     }
 }
@@ -283,7 +282,7 @@ struct PyFrame {
 
 impl PyFrame {
     fn new(frame: &Frame) -> Self {
-        let frametype = match frame.frame_type {
+        let frame_type = match frame.frame_type {
             FrameType::MS1 => 0,
             FrameType::MS2(x) => match x {
                 AcquisitionType::DDAPASEF => 1,
@@ -298,7 +297,7 @@ impl PyFrame {
             intensities: frame.intensities.to_owned(),
             index: frame.index.to_owned(),
             rt: frame.rt.to_owned(),
-            frame_type: frametype,
+            frame_type,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,7 +135,7 @@ impl TimsReader {
     fn __repr__(slf: &PyCell<Self>) -> PyResult<String> {
         let class_name: &str = slf.get_type().name()?;
         Ok(format!(
-            "{}(path={})",
+            "{}(path='{}')",
             class_name,
             slf.borrow().path.clone()
         ))
@@ -217,7 +217,7 @@ impl Display for PyPrecursor {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "(index={}, frame_index={}, mz={}, im={}, charge={}, intensity={})",
+            "PyPrecursor(index={}, frame_index={}, mz={}, im={}, charge={}, intensity={})",
             self.index, self.frame_index, self.mz, self.im, self.charge, self.intensity
         )
     }
@@ -316,21 +316,21 @@ impl PyFrame {
 }
 
 #[pyfunction]
-fn read_all_frames(a: String) -> PyResult<Vec<PyFrame>> {
-    let fr = timsrust::FileReader::new(&a).unwrap();
-    let fc = fr.get_frame_converter().unwrap();
-    let sc = fr.get_scan_converter().unwrap();
-    let tc = fr.get_tof_converter().unwrap();
+fn read_all_frames(path: String) -> PyResult<Vec<PyFrame>> {
+    let reader = timsrust::FileReader::new(&path).unwrap();
+    let fc = reader.get_frame_converter().unwrap();
+    let sc = reader.get_scan_converter().unwrap();
+    let tc = reader.get_tof_converter().unwrap();
 
-    let fr = TimsReader {
-        reader: fr,
-        path: a,
+    let tims_reader = TimsReader {
+        reader,
+        path,
         frame_converter: fc,
         scan_converter: sc,
         tof_converter: tc,
     };
 
-    let out: Vec<PyFrame> = fr.read_all_frames();
+    let out: Vec<PyFrame> = tims_reader.read_all_frames();
     Ok(out)
 }
 


### PR DESCRIPTION
Hi @jspaezp,

I was having an issue reading miniTDF DDA data. After propagating the error from timsrust, and with the help of @sander-willems-bruker, setting up the converters as part of `TimsReader` turned out to be the issue. As DDA miniTDF files do not contain all data that a DIA miniTDF would, it is not possible to set up, for instance, the `FrameConverter`.

This PR removes the instantiation of converters from the `TimsReader` class. That means that they are separately instantiated when calling `resolve_mzs`, `resolve_scans`, and `resolve_frames`. I'm not sure if that is desirable behavior? If not, we can come up with another solution that also works for DDA miniTDF.

Best,
Ralf

---

### Added

- Propagate error messages to Python (e.g. `OSError: Could not get frame converter: FileFormatError: MetadataFilesAreMissing` instead of only `OSError: Could not get frame converter`.

### Fixed

- Fix reading of DDA miniTDF files (`MS2Folder`) by not instantiating converters when not required.
- Fixed some object representation strings
- Clippy and formatting 
- Fix example in README and changed install instructions to use PyPI

### Changed

- Update `timsrust` to 0.2.3